### PR TITLE
(FIX): fix matomo by retrieving campaign pluggin

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -1018,7 +1018,6 @@ Plugins[] = Tour
 Plugins[] = EnvironmentVariables
 Plugins[] = DbCommands
 Plugins[] = AdminCommands
-Plugins[] = MarketingCampaignsReporting
 Plugins[] = TagManager
 Plugins[] = UsersFlow
 ;;;;;;;;;;


### PR DESCRIPTION
Retrait du MarketingCampaignsReporting 