### PR TITLE
Revert "(FIX): fix matomo by retrieving campaign pluggin"

### DIFF
--- a/config/global.ini.php
+++ b/config/global.ini.php
@@ -1018,6 +1018,7 @@ Plugins[] = Tour
 Plugins[] = EnvironmentVariables
 Plugins[] = DbCommands
 Plugins[] = AdminCommands
+Plugins[] = MarketingCampaignsReporting
 Plugins[] = TagManager
 Plugins[] = UsersFlow
 ;;;;;;;;;;


### PR DESCRIPTION
Resolves [PC-4543](https://passculture.atlassian.net/secure/RapidBoard.jspa?rapidView=33&modal=detail&selectedIssue=PC-4543)

Reverts pass-culture/pass-culture-web-analytics#9

Ce fix semble être à l'origine de problèmes d'archivage et de pre-processing des segments Matomo.
De plus le plugin MarketingCampainsReporting est toujours nécessaire pour les data analystes.